### PR TITLE
ASIC resistent mining using randomx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease 0.2.20",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.66",
+ "which",
+]
+
+[[package]]
 name = "bip39"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1544,15 @@ name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -4740,7 +4772,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "bzip2-sys",
  "cc",
  "glob",
@@ -7521,6 +7553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "randomx-rs"
+version = "1.3.0"
+source = "git+https://github.com/ulixee/randomx-rs?branch=main#32c42f1440adc8e5f08b983dc0c884580dbb1667"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -12190,6 +12232,7 @@ dependencies = [
  "ulx-node-consensus",
  "ulx-node-runtime",
  "ulx-primitives",
+ "ulx-randomx",
  "url",
 ]
 
@@ -12202,6 +12245,7 @@ dependencies = [
  "frame-support",
  "futures",
  "futures-timer",
+ "humantime",
  "jsonrpsee",
  "lazy_static",
  "log",
@@ -12250,6 +12294,7 @@ dependencies = [
  "ulx-notary",
  "ulx-notary-apis",
  "ulx-primitives",
+ "ulx-randomx",
 ]
 
 [[package]]
@@ -12420,6 +12465,24 @@ dependencies = [
  "thiserror",
  "tokio",
  "uniffi",
+]
+
+[[package]]
+name = "ulx-randomx"
+version = "0.0.1"
+dependencies = [
+ "bindgen 0.69.4",
+ "cmake",
+ "futures",
+ "hex",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "num_cpus",
+ "parking_lot 0.12.3",
+ "randomx-rs",
+ "sp-core",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "node",
     "node/consensus",
     "node/bitcoin_utxo_tracker",
+    "node/randomx",
     "pallets/bitcoin_utxos",
     "pallets/block_rewards",
     "pallets/block_seal",
@@ -130,6 +131,7 @@ parking_lot = { version = "0.12" }
 async-trait = { version = "0.1" }
 tokio = { version = "1.35", features = ["sync", "time", "rt"] }
 schnellru = { version = "0.2" }
+lru-cache = { version = "0.1.2" }
 getrandom = { version = "0.2" }
 rand = { version = "0.8.5" }
 lazy_static = "1.4.0"
@@ -154,6 +156,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 log = { version = "0.4", default-features = false }
 env_logger = "0.11"
+humantime = { version = "2.1" }
 
 sqlx = { version = "0.7", features = ["macros"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -263,6 +266,7 @@ napi-derive = { version = "2.16" }
 napi = { version = "2.16", features = ["napi9", "async", "error_anyhow"] }
 napi-build = { version = "2.1" }
 uniffi = { version = "0.27", features = ["tokio"] }
+randomx-rs = { git = "https://github.com/ulixee/randomx-rs", branch = "main" }
 
 clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 rpassword = { version = "7.3" }
@@ -270,6 +274,9 @@ comfy-table = { version = "7.1" }
 bech32 = { version = "0.11.0" }
 array-bytes = { version = "6.1" }
 directories = { version = "5.0" }
+
+bindgen = { version = "0.69" }
+cmake = { version = "0.1" }
 
 dotenv = { version = "0.15" }
 
@@ -283,6 +290,7 @@ ulx-node-consensus = { path = "node/consensus" }
 ulx-bitcoin-utxo-tracker = { path = "node/bitcoin_utxo_tracker" }
 ulx-node = { path = "node" }
 ulx-node-runtime = { path = "runtime" }
+ulx-randomx = { path = "node/randomx" }
 ulx-notary = { path = "notary" }
 ulx-notary-apis = { path = "notary/apis" }
 ulx-notary-audit = { path = "notary/audit", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -73,6 +73,7 @@ ulx-node-consensus = { workspace = true }
 ulx-node-runtime = { workspace = true, features = ["default"] }
 ulx-primitives = { workspace = true, features = ["default"] }
 ulx-bitcoin-utxo-tracker = { workspace = true }
+ulx-randomx = { workspace = true }
 
 # CLI-specific dependencies
 url = { workspace = true }

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -48,13 +48,14 @@ sc-utils = { workspace = true }
 sc-executor = { workspace = true, features = ["default"] }
 sp-io = { workspace = true, features = ["default"] }
 schnellru = { workspace = true }
+humantime = { workspace = true }
 
 # Local Dependencies
 ulx-primitives = { workspace = true, features = ["default"] }
 ulx-notary-apis = { workspace = true }
 ulx-node-runtime = { workspace = true, features = ["default"] }
 ulx-bitcoin-utxo-tracker = { workspace = true }
-
+ulx-randomx = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/node/consensus/src/compute_solver.rs
+++ b/node/consensus/src/compute_solver.rs
@@ -1,7 +1,8 @@
 use codec::Encode;
-use sp_core::{blake2_256, U256};
+use sp_core::{H256, U256};
 
 use ulx_primitives::*;
+use ulx_randomx::{calculate_hash, RandomXError};
 
 use crate::compute_worker::Version;
 
@@ -16,18 +17,27 @@ impl BlockComputeNonce {
 		self.nonce = self.nonce.checked_add(U256::one()).unwrap_or_default();
 	}
 
-	pub fn meets_threshold(hash: [u8; 32], threshold: U256) -> bool {
-		U256::from_big_endian(&hash) <= threshold
+	pub fn meets_threshold(hash: &[u8; 32], threshold: U256) -> bool {
+		U256::from_big_endian(hash) <= threshold
 	}
 
 	pub fn threshold(difficulty: ComputeDifficulty) -> U256 {
 		U256::MAX / U256::from(difficulty).max(U256::one())
 	}
 
-	pub fn is_valid(nonce: &U256, pre_hash: Vec<u8>, difficulty: ComputeDifficulty) -> bool {
-		let hash = Self { nonce: nonce.clone(), pre_hash }.using_encoded(blake2_256);
+	pub fn is_valid(
+		nonce: &U256,
+		pre_hash: Vec<u8>,
+		key_block_hash: &H256,
+		difficulty: ComputeDifficulty,
+	) -> bool {
+		let hash = Self { nonce: nonce.clone(), pre_hash }
+			.using_encoded(|x| calculate_hash(key_block_hash, x, false));
+		let Ok(hash) = hash else {
+			return false;
+		};
 		let threshold = Self::threshold(difficulty);
-		Self::meets_threshold(hash, threshold)
+		Self::meets_threshold(hash.as_fixed_bytes(), threshold)
 	}
 }
 
@@ -37,40 +47,49 @@ pub struct ComputeSolver {
 	pub wip_nonce: BlockComputeNonce,
 	pub wip_nonce_hash: Vec<u8>,
 	pub threshold: U256,
+	/// Stores the original difficulty supplied
+	pub difficulty: ComputeDifficulty,
+	pub key_block_hash: H256,
 }
 
 impl ComputeSolver {
-	pub fn new(version: Version, pre_hash: Vec<u8>, difficulty: ComputeDifficulty) -> Self {
+	pub fn new(
+		version: Version,
+		pre_hash: Vec<u8>,
+		key_block_hash: H256,
+		difficulty: ComputeDifficulty,
+	) -> Self {
 		let mut solver = ComputeSolver {
 			version,
 			threshold: BlockComputeNonce::threshold(difficulty),
 			wip_nonce_hash: vec![],
-			wip_nonce: BlockComputeNonce { nonce: U256::from(rand::random::<u64>()), pre_hash },
+			wip_nonce: BlockComputeNonce { nonce: U256::from(rand::random::<u128>()), pre_hash },
+			key_block_hash,
+			difficulty,
 		};
 		solver.wip_nonce_hash = solver.wip_nonce.encode().to_vec();
 		solver
 	}
 
 	/// Synchronous step to look at the next nonce
-	pub fn check_next(&mut self) -> Option<BlockComputeNonce> {
+	pub fn check_next(&mut self) -> Result<Option<BlockComputeNonce>, RandomXError> {
 		self.wip_nonce.increment();
 
 		let nonce_bytes = self.wip_nonce.nonce.encode();
 		let payload = &mut self.wip_nonce_hash;
 		payload.splice(payload.len() - nonce_bytes.len().., nonce_bytes);
 
-		let hash = blake2_256(&payload);
-		if BlockComputeNonce::meets_threshold(hash, self.threshold) {
-			return Some(self.wip_nonce.clone());
+		let hash = calculate_hash(&self.key_block_hash, &payload, true)?;
+		if BlockComputeNonce::meets_threshold(hash.as_fixed_bytes(), self.threshold) {
+			return Ok(Some(self.wip_nonce.clone()));
 		}
-		None
+		Ok(None)
 	}
 }
-
 #[cfg(test)]
 mod tests {
 	use codec::Encode;
-	use sp_core::U256;
+	use sp_core::{H256, U256};
 
 	use crate::{
 		compute_solver::{BlockComputeNonce, ComputeSolver},
@@ -85,8 +104,17 @@ mod tests {
 		let mut bytes = [0u8; 32];
 		bytes[31] = 1;
 
-		assert_eq!(BlockComputeNonce::is_valid(&U256::from(1), bytes.to_vec(), 1), true);
-		assert_eq!(BlockComputeNonce::is_valid(&U256::from(1), bytes.to_vec(), 10_000), false);
+		let key_block_hash = H256::from_slice(&[1u8; 32]);
+
+		assert_eq!(
+			BlockComputeNonce::is_valid(&U256::from(1), bytes.to_vec(), &key_block_hash, 1),
+			true
+		);
+
+		assert_eq!(
+			BlockComputeNonce::is_valid(&U256::from(1), bytes.to_vec(), &key_block_hash, 10_000),
+			false
+		);
 	}
 
 	#[test]
@@ -95,16 +123,22 @@ mod tests {
 
 		let mut bytes = [0u8; 32];
 		bytes[31] = 2;
+		let key_block_hash = H256::from_slice(&[1u8; 32]);
 		let pre_hash = bytes.to_vec();
-		let mut solver = ComputeSolver::new(Version(0), pre_hash.clone(), 1);
+		let mut solver = ComputeSolver::new(Version(0), pre_hash.clone(), key_block_hash, 1);
 
 		for _ in 0..100 {
-			let did_solve = solver.check_next().is_some();
+			let did_solve = solver.check_next().is_ok_and(|x| x.is_some());
 
 			assert_eq!(solver.wip_nonce_hash, solver.wip_nonce.encode());
 			assert_eq!(
 				did_solve,
-				BlockComputeNonce::is_valid(&solver.wip_nonce.nonce, pre_hash.clone(), 1)
+				BlockComputeNonce::is_valid(
+					&solver.wip_nonce.nonce,
+					pre_hash.clone(),
+					&key_block_hash,
+					1
+				)
 			);
 		}
 	}

--- a/node/consensus/src/compute_worker.rs
+++ b/node/consensus/src/compute_worker.rs
@@ -1,5 +1,6 @@
 use std::{
 	pin::Pin,
+	string::ToString,
 	sync::{
 		atomic::{AtomicUsize, Ordering},
 		Arc,
@@ -21,15 +22,17 @@ use sc_client_api::{AuxStore, BlockchainEvents, ImportNotifications};
 use sc_consensus::BoxBlockImport;
 use sc_service::TaskManager;
 use sp_api::ProvideRuntimeApi;
+use sp_arithmetic::traits::UniqueSaturatedInto;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{Environment, Proposal, Proposer, SelectChain, SyncOracle};
-use sp_core::{traits::SpawnEssentialNamed, RuntimeDebug, U256};
+use sp_core::{traits::SpawnEssentialNamed, RuntimeDebug, H256, U256};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use sp_timestamp::Timestamp;
 use ulx_bitcoin_utxo_tracker::UtxoTracker;
 
 use ulx_node_runtime::{NotaryRecordT, NotebookVerifyError};
 use ulx_primitives::{inherents::BlockSealInherentNodeSide, tick::Tick, *};
+use ulx_randomx::RandomXError;
 
 use crate::{
 	aux_client::UlxAux, block_creator, block_creator::propose, compute_solver::ComputeSolver,
@@ -48,6 +51,7 @@ pub struct MiningMetadata<H> {
 	pub import_time: Instant,
 	pub has_tax_votes: bool,
 	pub parent_tick: Tick,
+	pub key_block_hash: H256,
 }
 
 struct MiningBuild<B: BlockT, Proof> {
@@ -95,7 +99,13 @@ where
 		self.increment_version();
 	}
 
-	pub(crate) fn on_block(&self, best_hash: B::Hash, has_tax_votes: bool, parent_tick: Tick) {
+	pub(crate) fn on_block(
+		&self,
+		best_hash: B::Hash,
+		has_tax_votes: bool,
+		parent_tick: Tick,
+		key_block: H256,
+	) {
 		self.stop_solving_current();
 		let mut metadata = self.metadata.lock();
 		*metadata = Some(MiningMetadata {
@@ -103,6 +113,7 @@ where
 			has_tax_votes,
 			import_time: Instant::now(),
 			parent_tick,
+			key_block_hash: key_block,
 		});
 	}
 
@@ -135,6 +146,12 @@ where
 		self.metadata.lock().as_ref().map(|b| b.best_hash)
 	}
 
+	/// Get the current key block hash. `None` if the worker has just started or the client is doing
+	/// major syncing.
+	pub fn key_block_hash(&self) -> Option<H256> {
+		self.metadata.lock().as_ref().map(|b| b.key_block_hash)
+	}
+
 	pub fn build_hash(&self) -> Option<B::Hash> {
 		self.build
 			.lock()
@@ -149,11 +166,20 @@ where
 	}
 
 	pub fn create_solver(&self) -> Option<ComputeSolver> {
+		let key_block_hash = match self.metadata.lock().as_ref() {
+			Some(x) => x.key_block_hash,
+			_ => return None,
+		};
 		match self.build.lock().as_ref() {
 			Some(x) => {
 				let pre_hash = x.pre_hash;
 
-				Some(ComputeSolver::new(self.version(), pre_hash.as_ref().to_vec(), x.difficulty))
+				Some(ComputeSolver::new(
+					self.version(),
+					pre_hash.as_ref().to_vec(),
+					H256::from_slice(key_block_hash.as_ref()),
+					x.difficulty,
+				))
 			},
 			_ => None,
 		}
@@ -219,7 +245,7 @@ where
 	}
 }
 
-const LOG_TARGET: &str = "voter::compute::miner";
+const LOG_TARGET: &str = "node::compute::miner";
 pub(crate) fn create_compute_solver_task<B, L, Proof>(
 	mut worker: MiningHandle<B, L, Proof>,
 ) -> BoxFuture<'static, ()>
@@ -229,18 +255,29 @@ where
 	Proof: Send + 'static,
 {
 	async move {
-		let mut solver: Option<Box<ComputeSolver>> = None;
+		let mut solver_ref = None;
 		loop {
-			if !worker.is_valid_solver(&solver) {
-				solver = worker.create_solver().map(Box::new);
+			if !worker.is_valid_solver(&solver_ref) {
+				solver_ref = worker.create_solver().map(Box::new);
 			}
 
-			if let Some(solver) = solver.as_mut() {
-				if let Some(nonce) = solver.check_next() {
-					let _ = block_on(worker.submit(nonce.nonce));
-				}
-			} else {
+			let Some(solver) = solver_ref.as_mut() else {
 				tokio::time::sleep(Duration::from_millis(500)).await;
+				continue;
+			};
+
+			match solver.check_next() {
+				Ok(Some(nonce)) => {
+					let _ = block_on(worker.submit(nonce.nonce));
+				},
+				Ok(None) => (),
+				Err(RandomXError::CreationError(err)) => {
+					warn!("RandomX creation failed for mining: {:?}", err);
+					tokio::time::sleep(Duration::from_secs(10)).await;
+				},
+				Err(err) => {
+					warn!("Mining failed: {:?}", err);
+				},
 			}
 		}
 	}
@@ -340,8 +377,9 @@ where
 				let parent_tick = get_tick_digest(best_header.digest()).unwrap_or_default();
 				let votes_tick = parent_tick.saturating_sub(1);
 				let has_tax_votes = has_votes_at_tick(&client, &best_header, votes_tick);
+				let key_block = randomx_key_block(&client, &best_hash).unwrap_or_default();
 
-				mining_handle.on_block(best_hash, has_tax_votes, parent_tick);
+				mining_handle.on_block(best_hash, has_tax_votes, parent_tick, key_block);
 			}
 
 			let time = Timestamp::current();
@@ -396,6 +434,41 @@ where
 	};
 
 	(handle_to_return, task)
+}
+
+/// The key K is selected to be the hash of a block in the blockchain - this block is called the
+/// 'key block'. For optimal mining and verification performance, the key should change every 2048
+/// blocks (~2.8 days) and there should be a delay of 64 blocks (~2 hours) between the key block and
+/// the change of the key K. This can be achieved by changing the key when blockHeight % 2048 == 64
+/// and selecting key block such that keyBlockHeight % 2048 == 0.
+pub fn randomx_key_block<B, C>(client: &Arc<C>, parent_hash: &B::Hash) -> Result<H256, Error<B>>
+where
+	B: BlockT,
+	C: HeaderBackend<B>,
+{
+	const PERIOD: u32 = (1440.0 * 2.8) as u32; // 2.8 days
+	const OFFSET: u32 = 120; // 2 hours
+
+	let parent_number = client
+		.number(*parent_hash)
+		.map_err(|e| Error::Environment(format!("Client execution error: {:?}", e)))?
+		.ok_or(Error::Environment("Parent header not found".to_string()))?;
+	let parent_number = UniqueSaturatedInto::<u32>::unique_saturated_into(parent_number);
+
+	let mut key_block = parent_number.saturating_sub(parent_number % PERIOD);
+
+	// if we're before offset, stick with previous key block
+	if parent_number % PERIOD < OFFSET {
+		key_block = key_block.saturating_sub(PERIOD)
+	};
+
+	info!("Using key block: {}", key_block);
+
+	let hash = client
+		.hash(key_block.unique_saturated_into())
+		.map_err(|e| Error::Environment(format!("Key hash lookup error: {:?}", e)))?
+		.ok_or(Error::Environment("Key hash not found".to_string()))?;
+	Ok(H256::from_slice(hash.as_ref()))
 }
 
 /// A stream that waits for a block import or timeout.

--- a/node/consensus/src/error.rs
+++ b/node/consensus/src/error.rs
@@ -49,7 +49,7 @@ pub enum Error<B: BlockT> {
 	CreateInherents(sp_inherents::Error),
 	#[error("Checking inherents failed: {0}")]
 	CheckInherents(sp_inherents::Error),
-	#[error("Invalid compute nonce used")]
+	#[error("Invalid compute nonce provided")]
 	InvalidComputeNonce,
 	#[error(
 	"Checking inherents unknown error for identifier: {}",

--- a/node/consensus/src/import_queue.rs
+++ b/node/consensus/src/import_queue.rs
@@ -27,6 +27,7 @@ use crate::{
 	aux_client::UlxAux,
 	basic_queue::BasicQueue,
 	compute_solver::BlockComputeNonce,
+	compute_worker::randomx_key_block,
 	digests::{load_digests, read_seal_digest},
 	error::Error,
 	notary_client::verify_notebook_audits,
@@ -200,7 +201,13 @@ where
 							format!("Failed to get difficulty from runtime: {}", e).to_string(),
 						)
 					})?;
-				if !BlockComputeNonce::is_valid(nonce, pre_hash.as_ref().to_vec(), difficulty) {
+				let key_block_hash = randomx_key_block(&self.client, &parent_hash)?;
+				if !BlockComputeNonce::is_valid(
+					nonce,
+					pre_hash.as_ref().to_vec(),
+					&key_block_hash,
+					difficulty,
+				) {
 					return Err(Error::<B>::InvalidComputeNonce.into());
 				}
 				compute_difficulty = Some(difficulty);

--- a/node/consensus/src/tests/mod.rs
+++ b/node/consensus/src/tests/mod.rs
@@ -226,7 +226,7 @@ async fn can_build_compute_blocks() {
 	let net = UlxTestNet::new(
 		3,
 		Config {
-			difficulty: 10_000,
+			difficulty: 200,
 			tax_minimum: 1,
 			tick_duration: tick_duration.clone(),
 			genesis_utc_time: Ticker::start(tick_duration).genesis_utc_time,

--- a/node/randomx/Cargo.toml
+++ b/node/randomx/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ulx-randomx"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+publish = false
+
+[dependencies]
+thiserror = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }
+lazy_static = { workspace = true }
+lru-cache = { workspace = true }
+parking_lot = { workspace = true }
+log = { workspace = true }
+randomx-rs = { workspace = true }
+hex = { workspace = true }
+futures = { workspace = true }
+num_cpus = { workspace = true }
+
+[build-dependencies]
+bindgen = { workspace = true }
+cmake = { workspace = true }
+
+[dev-dependencies]

--- a/node/randomx/src/lib.rs
+++ b/node/randomx/src/lib.rs
@@ -1,0 +1,305 @@
+use std::{
+	cell::RefCell,
+	sync::{Arc, OnceLock},
+	thread::spawn,
+};
+
+use lazy_static::lazy_static;
+use log::info;
+use lru_cache::LruCache;
+use parking_lot::Mutex;
+pub use randomx_rs::RandomXError;
+use randomx_rs::{RandomXCache, RandomXDataset, RandomXFlag, RandomXVM};
+use sp_core::H256;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+	/// Recommended optimization: decreases the number of pages the system needs to manage, which
+	/// in turn reduces TLB (Translation Lookaside Buffer) misses and improves memory access speed
+	pub large_pages: bool,
+	/// Prevent side channel/timing attacks, but slower; also clears out memory after use
+	pub secure: bool,
+}
+impl Default for Config {
+	fn default() -> Self {
+		Self { large_pages: false, secure: false }
+	}
+}
+// Caches are shared cross threads
+lazy_static! {
+	static ref FULL_SHARED_CACHES: Arc<Mutex<LruCache<H256, Arc<VMData>>>> =
+		Arc::new(Mutex::new(LruCache::new(2)));
+	static ref LIGHT_SHARED_CACHES: Arc<Mutex<LruCache<H256, Arc<VMData>>>> =
+		Arc::new(Mutex::new(LruCache::new(3)));
+}
+
+// VMs are stored in thread local storage to avoid locking
+thread_local! {
+	// FULL uses a dataset (4gb of storage) but solves way faster
+	static FULL_VM: RefCell<Option<(H256, RandomXVM)>> = RefCell::new(None);
+	// LIGHT uses a cache (256mb of storage) but solves slower (appropriate for verification)
+	static LIGHT_VM: RefCell<Option<(H256, RandomXVM)>> = RefCell::new(None);
+}
+
+pub fn calculate_hash(
+	key_hash: &H256,
+	pre_hash: &[u8],
+	is_mining: bool,
+) -> Result<H256, RandomXError> {
+	alloc_vm_if_needed(key_hash, is_mining)?;
+
+	let ms = if is_mining { &FULL_VM } else { &LIGHT_VM };
+	match ms.with_borrow_mut(|vm| {
+		let (_, vm) = vm.as_mut().expect("Local VMS always set to Some above; qed");
+		vm.calculate_hash(pre_hash)
+	}) {
+		Err(e) => Err(e),
+		Ok(hash) => Ok(H256::from_slice(hash.as_ref())),
+	}
+}
+
+fn set_vm_data(is_mining: bool, data: &VMData, key_hash: &H256) -> Result<(), RandomXError> {
+	let vm = if is_mining { &FULL_VM } else { &LIGHT_VM };
+	vm.with_borrow_mut(|entry| {
+		if let Some((_, mut vm)) = entry.take() {
+			data.reinit(&mut vm, &key_hash[..])?;
+
+			*entry = Some((*key_hash, vm));
+		} else {
+			let new_vm = data.new_vm()?;
+			info!(target:"ulx-randomx", "Created new Randomx VM for key: {:?}", hex::encode(key_hash));
+			*entry = Some((*key_hash, new_vm));
+		};
+
+		Ok::<_, RandomXError>(())
+	})?;
+	Ok(())
+}
+
+fn vm_has_key(is_mining: bool, key_hash: &H256) -> bool {
+	let vm = if is_mining { &FULL_VM } else { &LIGHT_VM };
+	vm.with(|vm| {
+		if let Some((key, _)) = vm.borrow().as_ref() {
+			return key == key_hash;
+		}
+		false
+	})
+}
+
+fn alloc_vm_if_needed(key_hash: &H256, is_mining: bool) -> Result<(), RandomXError> {
+	if vm_has_key(is_mining, key_hash) {
+		return Ok(());
+	}
+
+	let mut shared_caches =
+		if is_mining { FULL_SHARED_CACHES.lock() } else { LIGHT_SHARED_CACHES.lock() };
+	// caches are static, while vms are per thread, so we this code is creating a new vm
+	let data: Arc<VMData> = if let Some(data) = shared_caches.get_mut(key_hash) {
+		data.clone()
+	} else if shared_caches.len() < shared_caches.capacity() || !global_config().large_pages {
+		Arc::new(VMData::new(&key_hash[..], &global_config(), is_mining)?)
+	} else {
+		// last case is using large pages
+		// replace the entry with a single entry
+		let key_to_replace = (*shared_caches)
+			.iter()
+			.find(|&(_, cache)| Arc::strong_count(cache) == 1)
+			.and_then(|(key, _)| Some(*key))
+			.ok_or(RandomXError::Other("Cache space not available".to_string()))?;
+
+		// we'll use the previous entry and just update it
+		shared_caches.remove(&key_to_replace).expect("key exists; qed")
+	};
+	shared_caches.insert(*key_hash, data.clone());
+	drop(shared_caches);
+
+	set_vm_data(is_mining, &data, key_hash)
+}
+
+static GLOBAL_CONFIG: OnceLock<Config> = OnceLock::new();
+
+pub fn global_config() -> Config {
+	GLOBAL_CONFIG.get().cloned().unwrap_or(Config::default())
+}
+
+pub fn set_global_config(config: Config) -> Result<(), Config> {
+	GLOBAL_CONFIG.set(config)
+}
+pub struct VMData {
+	cache: RandomXCache,
+	dataset: Option<RandomXDataset>,
+	flags: RandomXFlag,
+}
+
+unsafe impl Send for VMData {}
+unsafe impl Sync for VMData {}
+
+impl VMData {
+	pub fn new(key: &[u8], config: &Config, use_dataset: bool) -> Result<Self, RandomXError> {
+		let mut flags = RandomXFlag::get_recommended_flags();
+
+		if use_dataset {
+			flags = flags | RandomXFlag::FLAG_FULL_MEM;
+			if config.large_pages {
+				flags = flags | RandomXFlag::FLAG_LARGE_PAGES
+			}
+		}
+
+		if config.secure {
+			flags = flags | RandomXFlag::FLAG_SECURE
+		}
+
+		let cache = RandomXCache::new(flags, key)?;
+		if use_dataset {
+			let dataset = RandomXDataset::alloc(flags, cache.clone())?;
+			let instance = Self { cache, dataset: Some(dataset), flags };
+			instance.init_dataset()?;
+			return Ok(instance);
+		}
+
+		Ok(Self { cache, dataset: None, flags })
+	}
+
+	pub fn new_vm(&self) -> Result<RandomXVM, RandomXError> {
+		RandomXVM::new(self.flags, Some(self.cache.clone()), self.dataset.clone())
+	}
+
+	pub fn attach_to_vm(&self, vm: &mut RandomXVM) -> Result<(), RandomXError> {
+		if let Some(dataset) = self.dataset.clone() {
+			vm.reinit_dataset(dataset)?;
+		} else {
+			vm.reinit_cache(self.cache.clone())?;
+		}
+		Ok(())
+	}
+
+	pub fn init_dataset(&self) -> Result<(), RandomXError> {
+		let Some(dataset) = self.dataset.clone() else {
+			return Ok(());
+		};
+
+		let cpus_to_use = num_cpus::get() as u32 - 2;
+		let dataset_count = RandomXDataset::count()?;
+		let init_per_thread = dataset_count / cpus_to_use;
+		let remainder = dataset_count % cpus_to_use;
+
+		// dataset.init(0, dataset_count)?;
+		let mut start_ticker = 0;
+		let dataset_arc = Arc::new(dataset);
+		let spawned = (0..cpus_to_use)
+			.into_iter()
+			.map(|i| {
+				let dataset = dataset_arc.clone();
+
+				let mut count = init_per_thread;
+				if i == cpus_to_use - 1 {
+					count += remainder;
+				}
+				let start = start_ticker;
+				start_ticker += count;
+				spawn(move || dataset.init(start, count))
+			})
+			.collect::<Vec<_>>();
+
+		for handle in spawned {
+			handle.join().map_err(|e| {
+				RandomXError::CreationError(format!("Dataset init error: {:?}", e))
+			})??;
+		}
+		Ok(())
+	}
+
+	pub fn reinit(&self, vm: &mut RandomXVM, key: &[u8]) -> Result<(), RandomXError> {
+		self.cache.init(key)?;
+		self.init_dataset()?;
+		self.attach_to_vm(vm)?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_match_randomx_tests() {
+		// test that hashes from randomx source work
+		let cache = VMData::new(&b"test key 000"[..], &Default::default(), false).unwrap();
+		let mut vm = cache.new_vm().expect("Failed to create VM");
+		{
+			// test_a
+			let hash = vm.calculate_hash(&b"This is a test"[..]).unwrap();
+			assert_eq!(
+				hex::encode(hash),
+				"639183aae1bf4c9a35884cb46b09cad9175f04efd7684e7262a0ac1c2f0b4e3f"
+			);
+		}
+		{
+			// test_c
+			let hash = vm
+				.calculate_hash(
+					&b"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"[..],
+				)
+				.unwrap();
+			assert_eq!(
+				hex::encode(hash),
+				"c36d4ed4191e617309867ed66a443be4075014e2b061bcdaf9ce7b721d2b77a8"
+			);
+		}
+		cache.reinit(&mut vm, &b"test key 001"[..]).expect("Failed to reinit");
+		{
+			//test_d
+			let hash = vm
+				.calculate_hash(
+					&b"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"[..],
+				)
+				.unwrap();
+			assert_eq!(
+				hex::encode(hash),
+				"e9ff4503201c0c2cca26d285c93ae883f9b1d30c9eb240b820756f2d5a7905fc"
+			);
+		}
+		{
+			// test_e
+			let hash = vm
+				.calculate_hash(
+					&hex::decode(
+						"0b0b98bea7e805e0010a2126d287a2a0cc833d312cb786385a7c2f9de69d25537f584a9bc9977b00000000666fd8753bf61a8631f12984e3fd44f4014eca629276817b56f32e9b68bd82f416",
+					)
+					.unwrap(),
+				)
+				.unwrap();
+			assert_eq!(
+				hex::encode(hash),
+				"c56414121acda1713c2f2a819d8ae38aed7c80c35c2a769298d34f03833cd5f1"
+			);
+		}
+	}
+
+	#[test]
+	fn should_work_with_full_vm() {
+		let light_cache =
+			VMData::new(&b"RandomX example key"[..], &Default::default(), false).unwrap();
+		let light_vm = light_cache.new_vm().expect("Failed to create VM");
+		let hash = light_vm.calculate_hash(&b"RandomX example input"[..]).unwrap();
+		let full_cache =
+			VMData::new(&b"RandomX example key"[..], &Default::default(), true).unwrap();
+		let full_vm = full_cache.new_vm().expect("Failed to create VM");
+		let full_hash = full_vm.calculate_hash(&b"RandomX example input"[..]).unwrap();
+		assert_eq!(hash, full_hash);
+	}
+
+	#[test]
+	fn reinit_should_work() -> Result<(), String> {
+		let cache = VMData::new(&b"RandomX example key"[..], &Default::default(), true).unwrap();
+		let mut vm = cache.new_vm().unwrap();
+		let hash1 = vm.calculate_hash(&b"RandomX example input"[..]).unwrap();
+
+		cache.reinit(&mut vm, &b"RandomX example key 2"[..]).expect("Failed to reinit");
+
+		let hash2 = vm.calculate_hash(&b"RandomX example input"[..]).unwrap();
+		assert_ne!(hash1, hash2,);
+
+		Ok(())
+	}
+}

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -50,7 +50,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 	let mut properties = Properties::new();
 	properties.insert("tokenDecimals".into(), 3.into());
 
-	const HASHES_PER_SECOND: u64 = 100_000;
+	const HASHES_PER_SECOND: u64 = 100;
 
 	Ok(ChainSpec::builder(
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
@@ -93,7 +93,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 	let notary_host = env::var("ULX_LOCAL_TESTNET_NOTARY_URL")
 		.unwrap_or("ws://127.0.0.1:9925".to_string())
 		.into();
-
+	const HASHES_PER_SECOND: u64 = 1_000;
 	Ok(ChainSpec::builder(
 		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
 		None,
@@ -124,7 +124,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 		],
 		500,
-		(TICK_MILLIS * 1_000_000 / 1_000) as ComputeDifficulty,
+		(TICK_MILLIS * HASHES_PER_SECOND / 1_000) as ComputeDifficulty,
 		TICK_MILLIS,
 		vec![GenesisNotary {
 			account_id: get_account_id_from_seed::<sr25519::Public>("Ferdie"),

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use sc_cli::RunCmd;
 use ulx_node_runtime::AccountId;
 
@@ -23,6 +24,15 @@ pub struct Cli {
 	/// full node. Include optional auth inline
 	#[arg(long)]
 	pub bitcoin_rpc_url: String,
+
+	#[arg(long)]
+	pub randomx_flags: Vec<RandomxFlag>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum RandomxFlag {
+	LargePages,
+	Secure,
 }
 
 impl Cli {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -8,7 +8,7 @@ use ulx_node_runtime::{Block, EXISTENTIAL_DEPOSIT};
 use crate::{
 	benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
 	chain_spec,
-	cli::{Cli, Subcommand},
+	cli::{Cli, RandomxFlag, Subcommand},
 	service,
 };
 
@@ -184,6 +184,16 @@ pub fn run() -> sc_cli::Result<()> {
 		},
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
+
+			let mut randomx_config = ulx_randomx::Config::default();
+			if cli.randomx_flags.contains(&RandomxFlag::LargePages) {
+				randomx_config.large_pages = true;
+			}
+			if cli.randomx_flags.contains(&RandomxFlag::Secure) {
+				randomx_config.secure = true;
+			}
+			let _ = ulx_randomx::set_global_config(randomx_config);
+
 			runner.run_node_until_exit(|config| async move {
 				match config.network.network_backend {
 					sc_network::config::NetworkBackendType::Libp2p => service::new_full::<


### PR DESCRIPTION
This PR replaces our POW that previously used blake2 hashing with the RandomX hashing protocol designed for the Monero blockchain.

RandomX works by creating programs on the fly that are run in a VM that exercise general computing features, including math, memory problems, branching logic, and more. It outputs a hash from the deterministic logic of the program. Fast generation of hashes requires 2GB of memory to be loaded up in memory. Validation can be done more slowly but without all the memory using "Light" mode. The VMs will rotate keys every 2.8 days of blocks, which ensures programs continue to provide equally hard problems that are hard to build ASIC programs around, but not too hard on the computer, which has to rebuild the entire 2GB dataset when this happens.